### PR TITLE
Added a framework for a table of all commands

### DIFF
--- a/_commands/geld.md
+++ b/_commands/geld.md
@@ -1,4 +1,5 @@
 ---
-command: "geld"
+command: "/geld"
+aliases: "/konto"
 ---
 Finde heraus, wie viel Geld du hast.

--- a/_commands/geld.md
+++ b/_commands/geld.md
@@ -1,0 +1,4 @@
+---
+command: "geld"
+---
+Finde heraus, wie viel Geld du hast.

--- a/_commands/willkommen.md
+++ b/_commands/willkommen.md
@@ -1,0 +1,4 @@
+---
+command: "willkommen"
+---
+Begrüße einen neu gejointen Spieler.

--- a/_commands/willkommen.md
+++ b/_commands/willkommen.md
@@ -1,4 +1,5 @@
 ---
-command: "willkommen"
+command: "/willkommen [Nachricht]"
 ---
-Begrüße einen neu gejointen Spieler.
+Begrüße einen neu gejointen Spieler. Du kannst optional eine personalisierte
+Nachricht ergänzen.

--- a/_config.yml
+++ b/_config.yml
@@ -17,6 +17,8 @@ color_scheme: dark
 collections:
   team_members:
     name: Team Members
+  commands:
+    name: Commands
   tutorials:
     permalink: "/:collection/:path/"
     output: true

--- a/commands.md
+++ b/commands.md
@@ -7,7 +7,9 @@ permalink: /commands
 # Commands
 
 Im Folgenden findet ihr eine Auflistung aller Commands auf Farmlife: Badoras
-(ohne Garantie auf Vollständigkeit).
+(ohne Garantie auf Vollständigkeit). Wir verwenden dabei folgende Konvention:
+- Notwendige Argumente werden mit spitzen Klammern dargestellt. Bsp.: `<Argument>`
+- Optionale Argumente werden mit eckigen Klammern dargestellt. Bsp.: `[Argument]`
 
 <table>
 	<tr>
@@ -17,14 +19,20 @@ Im Folgenden findet ihr eine Auflistung aller Commands auf Farmlife: Badoras
 		<th>
 			Beschreibung
 		</th>
+		<th>
+			Aliases
+		</th>
 	</tr>
 	{% for command in site.commands %}
 	<tr>
 		<td>
-			<center><pre>/{{ command.command }}</pre></center>
+			<center><pre>{{ command.command }}</pre></center>
 		</td>
 		<td>
 			<center>{{ command.content }}</center>
+		</td>
+		<td>
+			<center><pre>{{ command.aliases }}</pre></center>
 		</td>
 	</tr>
 	{% endfor %}

--- a/commands.md
+++ b/commands.md
@@ -1,0 +1,31 @@
+---
+title: Commands
+layout: default
+permalink: /commands
+---
+
+# Commands
+
+Im Folgenden findet ihr eine Auflistung aller Commands auf Farmlife: Badoras
+(ohne Garantie auf Vollständigkeit).
+
+<table>
+	<tr>
+		<th>
+			Command
+		</th>
+		<th>
+			Beschreibung
+		</th>
+	</tr>
+	{% for command in site.commands %}
+	<tr>
+		<td>
+			<center><pre>/{{ command.command }}</pre></center>
+		</td>
+		<td>
+			<center>{{ command.content }}</center>
+		</td>
+	</tr>
+	{% endfor %}
+</table>


### PR DESCRIPTION
The wiki now contains a site called "Commands", where all ingame commands are listed in one table. This list can be easily extended by creating a file in _commands.