### PR TITLE
Enabled images in lists

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -138,3 +138,32 @@ Hier entsteht eine Liste von Farben.
 
 Eine Liste kann also entsprechend erweitert werden, indem neue Objekte ergänzt
 werden.
+
+Es ist möglich, Bilder in Listen anzuzeigen. Hierzu ein Beispiel:
+
+```md
+---
+short_name: sealife
+title: Meereswesen
+layout: default
+
+table:
+  headers:
+    - Meereswesen
+    - Gefunden von
+    - Fundort
+  objects:
+    - attributes:
+        - Feuerfisch
+        - motrellin
+        - "![grafik](/assets/images/wikibanner.jpg)"
+---
+# {{ page.title }}
+
+Viele verschiedene Wesen können z.B. am Hafen geangelt werden. Im Folgenden
+entsteht eine Liste an geangelten Wesen, die gerne erweitert werden darf.
+
+{% include lists_table.md %}
+```
+
+Es ist wichtig, die entsprechende Zeile in Anführungszeichen zu setzen.

--- a/_includes/lists_table.md
+++ b/_includes/lists_table.md
@@ -14,7 +14,7 @@ alphabetisch sortiert werden, bitte beim Einfügen beachten.
  <tr>
   {% for attr in object.attributes %}
   <td>
-   <center>{{ attr }}</center>
+   <center>{{ attr | markdownify }}</center>
   </td>
   {% endfor %}
  </tr>


### PR DESCRIPTION
It is now possible to use images in lists. Here is an example:
```md
---
short_name: sealife
title: Meereswesen
layout: default

table:
  headers:
    - Meereswesen
    - Gefunden von
    - Fundort
  objects:
    - attributes:
        - Feuerfisch
        - motrellin
        - "![grafik](/assets/images/wikibanner.jpg)"
---

Viele verschiedene Wesen können z.B. am Hafen geangelt werden. Im Folgenden
entsteht eine Liste an geangelten Wesen, die gerne erweitert werden darf.

{% include lists_table.md %}
```
Note that it's important to use quotation marks to surround the image content.

A similar description was also added to `.github/CONTRIBUTING.md`.

<!-- Bitte beschreibe deine Änderungen hier. -->

---

### Related Issues
<!-- Falls das eine bestehende Issue löst, erwähne diese Issue bitte hier -->
Closes #XXXX

### Reviewer's checklist
<!-- DON'T DO ANYTHING HERE -->
<!-- This is a checklist for the reviewers, and will be checked by them! -->
- [ ] ... Wurde eine gewisse Code-Qualität eingehalten?
- [ ] ... Stimmen die veränderten oder neu hinzugefügten Informationen?
- [ ] ... Wurden die Veränderungen getestet?
